### PR TITLE
ci(release): bind release workflow to production environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
   release-image:
     name: release-image
     runs-on: ubuntu-latest
+    environment: production
     env:
       IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/telegram-wp-linkedin
     steps:

--- a/docs/04-operations/docker-cicd-strategy.md
+++ b/docs/04-operations/docker-cicd-strategy.md
@@ -40,6 +40,7 @@ Comandos base:
 - Trigger: `push` sobre tags `v*.*.*`
 - Job/check estable: `release-image`
 - Accion: build + push de imagen a `ghcr.io/<org>/telegram-wp-linkedin` con tag semantico y `latest`
+- Environment objetivo: `production` (con required reviewer y policy de ramas protegidas)
 
 ### 3. Deploy (solo cuando aplique)
 


### PR DESCRIPTION
Closes #3\n\n## Summary\n- Enlaza elease-image al environment production para activar reglas de deployment governance.\n- Alinea la doc de estrategia CI/CD con el environment objetivo real.\n\n## Changes\n| File | Change |\n|------|--------|\n| .github/workflows/release.yml | Agrega environment: production al job elease-image |\n| docs/04-operations/docker-cicd-strategy.md | Documenta environment objetivo production |\n\n## Test Plan\n- [x] Validacion de sintaxis del workflow por diff y convenciones existentes\n- [x] Verificacion de policy en environment production (required reviewer + protected branches)