### PR TITLE
ci(cost): switch PR gates to manual low-cost mode

### DIFF
--- a/.github/workflows/pr-gates.yml
+++ b/.github/workflows/pr-gates.yml
@@ -1,9 +1,7 @@
 name: PR Gates
 
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/docs/04-operations/branching-governance.md
+++ b/docs/04-operations/branching-governance.md
@@ -27,18 +27,20 @@ Ejemplos:
 
 - PR chica (ideal <= 300 lineas netas).
 - Commits atomicos por unidad semantica.
-- Checks obligatorios en verde: `quality-pr` y `security-pr`.
+- Validacion local obligatoria en verde: `./scripts/local-quality-gate.ps1` y `./scripts/local-security-scan.ps1`.
+- Validacion cloud opcional/manual: workflow `PR Gates` via `workflow_dispatch` cuando se requiere evidencia remota.
 - Minimo 1 aprobacion antes de merge.
 - Merge squash permitido solo si conserva mensaje semantico claro.
 
-## Required checks en branch protection (`main`)
+## Branch protection en `main`
 
 Configurar en GitHub -> Settings -> Branches -> Branch protection rule sobre `main`:
 
-- `quality-pr`
-- `security-pr`
+- minimo 1 aprobacion
+- required conversation resolution
+- no direct pushes / no force pushes
 
-Estos nombres deben mantenerse estables para evitar drift entre governance y CI.
+No se fuerzan required status checks para mantener costo cloud minimo.
 
 ## Commits (conventional commits)
 

--- a/docs/04-operations/docker-cicd-strategy.md
+++ b/docs/04-operations/docker-cicd-strategy.md
@@ -29,10 +29,11 @@ Comandos base:
 ### 1. PR Gates (implementado)
 
 - Workflow: `.github/workflows/pr-gates.yml`
-- Trigger: `pull_request` hacia `main`
+- Trigger: `workflow_dispatch` (manual)
 - Jobs/checks estables:
   - `quality-pr` -> `ruff check app tests` + `pytest -q`
   - `security-pr` -> `pip-audit` + `gitleaks`
+- Uso recomendado: ejecutar manualmente solo en hitos/riesgo alto para evidencia remota sin costo recurrente por PR.
 
 ### 2. Release por tags semanticos (implementado)
 
@@ -51,8 +52,8 @@ Comandos base:
 
 - Trunk-based development con PRs cortas.
 - Protecciones en `main`:
-  - checks obligatorios: `quality-pr`, `security-pr`
-  - 1 o 2 approvals
+  - 1 aprobacion obligatoria
+  - conversation resolution obligatoria
   - no direct pushes
 
 ## Estrategia de despliegue


### PR DESCRIPTION
Closes #5\n\n## Summary\n- Cambia PR Gates de trigger automatico por PR a ejecucion manual (workflow_dispatch).\n- Mantiene governance enterprise en main con aprobacion obligatoria y conversation resolution.\n- Alinea documentacion operativa al modelo local-first con evidencia cloud opcional.\n\n## Changes\n| File | Change |\n|------|--------|\n| .github/workflows/pr-gates.yml | Trigger cambiado a workflow_dispatch |\n| docs/04-operations/branching-governance.md | Reglas de PR y branch protection sin required checks cloud |\n| docs/04-operations/docker-cicd-strategy.md | Estrategia costo-aware con PR gates manuales |\n\n## Test Plan\n- [x] Verificacion de branch protection en main (sin required status checks, 1 review, conversation resolution)\n- [x] Revisión de consistencia entre workflow y documentación