### PR TITLE
ci(release): run controlled validation without latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,6 @@ jobs:
           images: ${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ github.ref_name }}
-            type=raw,value=latest
 
       - name: Build and push image
         uses: docker/build-push-action@v6

--- a/docs/04-operations/docker-cicd-strategy.md
+++ b/docs/04-operations/docker-cicd-strategy.md
@@ -40,7 +40,7 @@ Comandos base:
 - Workflow: `.github/workflows/release.yml`
 - Trigger: `push` sobre tags `v*.*.*`
 - Job/check estable: `release-image`
-- Accion: build + push de imagen a `ghcr.io/<org>/telegram-wp-linkedin` con tag semantico y `latest`
+- Accion: build + push de imagen a `ghcr.io/<org>/telegram-wp-linkedin` con tag semantico (sin `latest` en validacion controlada)
 - Environment objetivo: `production` (con required reviewer y policy de ramas protegidas)
 
 ### 3. Deploy (solo cuando aplique)


### PR DESCRIPTION
Closes #7\n\n## Summary\n- Ajusta el workflow de release para no publicar latest durante la validación controlada.\n- Mantiene publicación por tag semántico para validar build/push en GHCR con menor riesgo operativo.\n\n## Changes\n| File | Change |\n|------|--------|\n| .github/workflows/release.yml | Quita latest de tags de metadata para la corrida controlada |\n| docs/04-operations/docker-cicd-strategy.md | Aclara que validación controlada publica solo tag semántico |\n\n## Test Plan\n- [x] Revisión de trigger y tags generados en workflow\n- [x] Revisión de consistencia documental