### PR TITLE
docs(operations): formalize ultra low-cost actions policy

### DIFF
--- a/docs/04-operations/docker-cicd-strategy.md
+++ b/docs/04-operations/docker-cicd-strategy.md
@@ -26,6 +26,11 @@ Comandos base:
 
 ## GitHub Actions (minimo costo-aware)
 
+Estado actual para costo minimo:
+
+- `PR Gates`: desactivado en GitHub (se mantiene workflow versionado para posible uso futuro).
+- `Release Image`: activo solo por tags semanticos y con aprobacion de environment `production`.
+
 ### 1. PR Gates (implementado)
 
 - Workflow: `.github/workflows/pr-gates.yml`

--- a/docs/04-operations/runbook.md
+++ b/docs/04-operations/runbook.md
@@ -35,6 +35,31 @@ Notas:
 - gate local en verde (`local-quality-gate.ps1` + `local-security-scan.ps1`, ambos obligatorios).
 - cumplimiento de `docs/06-security/secrets-operating-standard.md`.
 
+## Politica de uso minimo de GitHub Actions (cost control)
+
+Objetivo: minimizar minutos cloud manteniendo gobernanza enterprise.
+
+Reglas operativas:
+
+- `PR Gates` desactivado por defecto para evitar costo recurrente por cada PR.
+- validacion obligatoria ocurre localmente antes de abrir/mergear PR:
+  - `./scripts/local-quality-gate.ps1`
+  - `./scripts/local-security-scan.ps1`
+- `Release Image` se usa solo para releases reales por tag semantico (`v*.*.*`).
+- evitar tags de prueba frecuentes; agrupar cambios y releasear en lotes razonables.
+
+Cuando SI correr Actions:
+
+- release candidate que realmente podria promoverse a produccion
+- cambio de Dockerfile/base image o cadena de build de contenedor
+- cambio de permisos/policies en environments o publish a GHCR
+
+Cuando NO correr Actions:
+
+- PRs de documentacion
+- refactors internos sin impacto en imagen/release
+- pruebas exploratorias que pueden validarse completamente en local
+
 Ejecucion recomendada del gate local:
 
 ```powershell


### PR DESCRIPTION
Closes #9\n\n## Summary\n- Documenta una política explícita de uso mínimo de GitHub Actions para reducir costo cloud.\n- Define criterios claros de cuándo ejecutar Actions y cuándo validar solo en local.\n\n## Changes\n| File | Change |\n|------|--------|\n| docs/04-operations/runbook.md | Nueva sección de política de cost control para Actions |\n| docs/04-operations/docker-cicd-strategy.md | Estado operativo actual: PR Gates desactivado y Release activo por tags |\n\n## Test Plan\n- [x] Revisión de consistencia con configuración actual de workflows\n- [x] Verificación de claridad operativa para minimizar ejecuciones innecesarias