### PR TITLE
docs(operations): establish low-cost release cadence

### DIFF
--- a/docs/04-operations/docker-cicd-strategy.md
+++ b/docs/04-operations/docker-cicd-strategy.md
@@ -30,6 +30,7 @@ Estado actual para costo minimo:
 
 - `PR Gates`: desactivado en GitHub (se mantiene workflow versionado para posible uso futuro).
 - `Release Image`: activo solo por tags semanticos y con aprobacion de environment `production`.
+- Cadencia recomendada de tags de release: quincenal, excepto hotfix critico.
 
 ### 1. PR Gates (implementado)
 

--- a/docs/04-operations/runbook.md
+++ b/docs/04-operations/runbook.md
@@ -60,6 +60,38 @@ Cuando NO correr Actions:
 - refactors internos sin impacto en imagen/release
 - pruebas exploratorias que pueden validarse completamente en local
 
+## Cadencia de release recomendada (costo-controlada)
+
+Objetivo: reducir ejecuciones de `Release Image` sin perder trazabilidad.
+
+Politica:
+
+- frecuencia base: release quincenal (cada 2 semanas)
+- excepcion: hotfix critico (Sev1/Sev2) permite release inmediato
+- evitar tags intermedios para pruebas; usar validacion local para iteraciones
+
+Ventana sugerida:
+
+- martes o miercoles, horario laboral (evita aprobaciones fuera de horario)
+- checklist previo obligatorio en local:
+  - `./scripts/local-quality-gate.ps1`
+  - `./scripts/local-security-scan.ps1`
+
+Convencion de versionado:
+
+- `vMAJOR.MINOR.PATCH`
+- `PATCH`: bugfixes/hardening sin cambios de contrato
+- `MINOR`: mejoras compatibles
+- `MAJOR`: cambios incompatibles o rediseño operativo
+
+Flujo minimo por release:
+
+1. consolidar cambios listos en `main`
+2. ejecutar gates locales obligatorios
+3. crear tag semantico (`vX.Y.Z`) sobre `main`
+4. aprobar deployment de `production` en GitHub Actions
+5. registrar resultado en runbook/incidente si hubo desvio
+
 Ejecucion recomendada del gate local:
 
 ```powershell


### PR DESCRIPTION
Closes #11\n\n## Summary\n- Define cadencia quincenal de release para minimizar ejecuciones de Actions sin perder trazabilidad.\n- Documenta excepciones de hotfix y flujo mínimo de release con aprobación de environment.\n\n## Changes\n| File | Change |\n|------|--------|\n| docs/04-operations/runbook.md | Nueva política de cadencia, versionado y flujo de release |\n| docs/04-operations/docker-cicd-strategy.md | Nota de cadencia recomendada de tags |\n\n## Test Plan\n- [x] Revisión de consistencia con estrategia ultra low-cost actual\n- [x] Verificación de claridad operativa para ejecutar menos workflows