### PR TITLE
chore(git): enforce mandatory local gates on pre-push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+set -eu
+
+if command -v pwsh >/dev/null 2>&1; then
+  PS_CMD="pwsh"
+elif command -v powershell >/dev/null 2>&1; then
+  PS_CMD="powershell"
+else
+  echo "[hook:pre-push] ERROR: PowerShell runtime not found (pwsh/powershell)." >&2
+  exit 1
+fi
+
+echo "[hook:pre-push] running local quality gate"
+"$PS_CMD" -NoProfile -ExecutionPolicy Bypass -File "scripts/local-quality-gate.ps1"
+
+echo "[hook:pre-push] running local security scan"
+"$PS_CMD" -NoProfile -ExecutionPolicy Bypass -File "scripts/local-security-scan.ps1"
+
+echo "[hook:pre-push] local gates passed"

--- a/README.md
+++ b/README.md
@@ -11,3 +11,19 @@ Automation pipeline to process Telegram updates and publish content to WordPress
 ```bash
 python -m app.main run-once --dry-run --db-path data/app.db
 ```
+
+## Local gate enforcement
+
+This repository enforces local quality/security gates on `git push` using a versioned pre-push hook.
+
+Setup once per clone:
+
+```bash
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-push
+```
+
+The pre-push hook runs:
+
+- `scripts/local-quality-gate.ps1`
+- `scripts/local-security-scan.ps1`


### PR DESCRIPTION
Closes #14

## PR Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds a versioned `pre-push` hook to enforce mandatory local gates before any push.
- Runs both local quality and security scripts in the hook with explicit PowerShell runtime detection.
- Documents one-time setup (`core.hooksPath`) in README for consistent team adoption.

## Changes
| File | Change |
|------|--------|
| `.githooks/pre-push` | Added pre-push hook that executes `local-quality-gate.ps1` and `local-security-scan.ps1` |
| `README.md` | Added local gate enforcement section and setup commands |

## Test Plan
- [x] `git push -u origin chore/enforce-local-gates`
- [x] Hook executed and enforced local gates during push
- [x] `ruff`, `mypy`, `pytest`, `gitleaks`, `trivy` passed
- [x] `pip-audit` ran and reported existing known vulnerability `CVE-2026-3219` in `pip 26.0.1`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers